### PR TITLE
Multiple Window Management Woes

### DIFF
--- a/grocery-list.html
+++ b/grocery-list.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Grocery List</title>
+  </head>
+  <body>
+    <p>Muh grocery list</p>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
       Recipes go here!
     </section>
     <section id="grocery-list-area">
-      <button id="grocery-list-btn">Grocery List</button>
+      <a id="grocery"><button id="grocery-list-btn">Grocery List</button>
       <textarea class="grocery-list"></textarea>
     </section>
   </body>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@
     </section>
     <section id="grocery-list-area">
       <a id="grocery"><button id="grocery-list-btn">Grocery List</button>
-      <textarea class="grocery-list"></textarea>
     </section>
   </body>
 

--- a/index.html
+++ b/index.html
@@ -12,6 +12,10 @@
     <section id="recipe-box">
       Recipes go here!
     </section>
+    <section id="grocery-list-area">
+      <button id="grocery-list-btn">Grocery List</button>
+      <textarea class="grocery-list"></textarea>
+    </section>
   </body>
 
   <script>

--- a/main.js
+++ b/main.js
@@ -37,7 +37,7 @@ function createWindow () {
 
   // Emitted when the window is closed.
   mainWindow.on('closed', function () {
-    
+
     mainWindow = null
   })
 }

--- a/main.js
+++ b/main.js
@@ -13,6 +13,7 @@ const menubar = Menubar({
   icon: './images/kitchen-fork-icon.png'
 })
 
+
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let mainWindow
@@ -21,16 +22,38 @@ menubar.on('ready', () => {
   console.log('READY!');
 })
 
+const windows = new Set()
+// creates fancy array of windows
+
+const createGroceryList = exports.createGroceryList = (file) => {
+  let groceryWindow = new BrowserWindow({show: false})
+  windows.add(groceryWindow)
+  //creates a new window for the grocery list and defaults it to not show. We add this window to the window Set
+
+  //load grocery list file
+  groceryWindow.loadURL('file://' + __dirname + '/grocery-list.html')
+
+  groceryWindow.once('ready-to-show', () => {
+    if (file) openFile(groceryWindow, file)
+    groceryWindow.show()
+    //Once the new window is ready to show, we will call openFiel if there is a file to open with the new window. Then we show the new window.
+  })
+
+  return groceryWindow
+}
+
 function createWindow () {
   // Create the browser window.
   mainWindow = new BrowserWindow({width: 800, height: 600})
+
 
   // and load the index.html of the app.
   mainWindow.loadURL(url.format({
     pathname: path.join(__dirname, 'index.html'),
     protocol: 'file:',
     slashes: true
-  }))
+  })
+)
 
   // Open the DevTools.
   mainWindow.webContents.openDevTools()
@@ -40,6 +63,8 @@ function createWindow () {
 
     mainWindow = null
   })
+
+
 }
 
 // This method will be called when Electron has finished

--- a/main.js
+++ b/main.js
@@ -1,92 +1,60 @@
 const Menubar = require('menubar')
 const electron = require('electron')
-// Module to control application life.
 const app = electron.app
-// Module to create native browser window.
 const BrowserWindow = electron.BrowserWindow
 
 const path = require('path')
 const url = require('url')
-// const menubar = Menubar({
-//   width:300,
-//   height:400,
-//   icon: './images/kitchen-fork-icon.png'
-// })
+const menubar = Menubar({
+  width:300,
+  height:400,
+  icon: './images/kitchen-fork-icon.png'
+})
 
-
-// Keep a global reference of the window object, if you don't, the window will
-// be closed automatically when the JavaScript object is garbage collected.
 let mainWindow
 
-// menubar.on('ready', () => {
-//   console.log('READY!');
-// })
-
 const windows = new Set()
-// creates fancy array of windows
 
 const createGroceryList = exports.createGroceryList = (file) => {
   let groceryWindow = new BrowserWindow({show: false})
   windows.add(groceryWindow)
-  //creates a new window for the grocery list and defaults it to not show. We add this window to the window Set
-
-  //load grocery list file
   groceryWindow.loadURL('file://' + __dirname + '/grocery-list.html')
 
   groceryWindow.once('ready-to-show', () => {
     if (file) openFile(groceryWindow, file)
     groceryWindow.show()
-    //Once the new window is ready to show, we will call openFiel if there is a file to open with the new window. Then we show the new window.
   })
 
   return groceryWindow
 }
 
 function createWindow () {
-  // Create the browser window.
   mainWindow = new BrowserWindow({width: 800, height: 600})
 
-
-  // and load the index.html of the app.
   mainWindow.loadURL(url.format({
     pathname: path.join(__dirname, 'index.html'),
     protocol: 'file:',
     slashes: true
   })
 )
-
-  // Open the DevTools.
   mainWindow.webContents.openDevTools()
 
-  // Emitted when the window is closed.
   mainWindow.on('closed', function () {
-
     mainWindow = null
   })
 }
 
-// This method will be called when Electron has finished
-// initialization and is ready to create browser windows.
-// Some APIs can only be used after this event occurs.
 app.on('ready', () => {
   createWindow()})
 
-// Quit when all windows are closed.
 app.on('window-all-closed', function () {
-  // On OS X it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform !== 'darwin') {
     app.quit()
   }
 })
 
 app.on('activate', function () {
-  // On OS X it's common to re-create a window in the app when the
-  // dock icon is clicked and there are no other windows open.
   if (mainWindow === null) {
     createWindow()
   }
 })
-
-// In this file you can include the rest of your app's specific main process
-// code. You can also put them in separate files and require them here.

--- a/main.js
+++ b/main.js
@@ -7,20 +7,20 @@ const BrowserWindow = electron.BrowserWindow
 
 const path = require('path')
 const url = require('url')
-const menubar = Menubar({
-  width:300,
-  height:400,
-  icon: './images/kitchen-fork-icon.png'
-})
+// const menubar = Menubar({
+//   width:300,
+//   height:400,
+//   icon: './images/kitchen-fork-icon.png'
+// })
 
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let mainWindow
 
-menubar.on('ready', () => {
-  console.log('READY!');
-})
+// menubar.on('ready', () => {
+//   console.log('READY!');
+// })
 
 const windows = new Set()
 // creates fancy array of windows
@@ -63,14 +63,13 @@ function createWindow () {
 
     mainWindow = null
   })
-
-
 }
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.on('ready', createWindow)
+app.on('ready', () => {
+  createWindow()})
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function () {

--- a/renderer.js
+++ b/renderer.js
@@ -2,7 +2,6 @@
 // be executed in the renderer process for that window.
 // All of the Node.js APIs are available in this process.
 const electron = require('electron')
-const mainProcess = require('./main')
 const $ = require('jquery');
 
 const ipc = electron.ipcRenderer
@@ -37,7 +36,7 @@ const validateUrl = (link) => {
 }
 
 $('#grocery-list-btn').on('click', (e) => {
-  e.preventDefault()
+  debugger
   //when I click on the grocery list button, a text area should pop up with a save button.
   createGroceryList()
 }) // new window will not pop up

--- a/renderer.js
+++ b/renderer.js
@@ -1,8 +1,13 @@
 // This file is required by the index.html file and will
 // be executed in the renderer process for that window.
 // All of the Node.js APIs are available in this process.
-
+const electron = require('electron')
+const mainProcess = require('./main')
 const $ = require('jquery');
+
+const ipc = electron.ipcRenderer
+const remote = electron.remote
+const shell = electron.shell
 
 $('#save-recipe-btn').on('click', () => {
   const title = $('#title-field').val();
@@ -26,3 +31,9 @@ const validateUrl = (link) => {
   }
   return link;
 }
+
+$('#grocery-list-btn').on('click', (e) => {
+  //when I click on the grocery list button, a text area should pop up with a save button.
+  e.preventDefault()
+  shell.openExternal(this.)
+})

--- a/renderer.js
+++ b/renderer.js
@@ -35,5 +35,4 @@ const validateUrl = (link) => {
 $('#grocery-list-btn').on('click', (e) => {
   //when I click on the grocery list button, a text area should pop up with a save button.
   e.preventDefault()
-  shell.openExternal(this.)
 })

--- a/renderer.js
+++ b/renderer.js
@@ -1,6 +1,3 @@
-// This file is required by the index.html file and will
-// be executed in the renderer process for that window.
-// All of the Node.js APIs are available in this process.
 const electron = require('electron')
 const $ = require('jquery');
 
@@ -36,7 +33,5 @@ const validateUrl = (link) => {
 }
 
 $('#grocery-list-btn').on('click', (e) => {
-  debugger
-  //when I click on the grocery list button, a text area should pop up with a save button.
   createGroceryList()
-}) // new window will not pop up
+})

--- a/renderer.js
+++ b/renderer.js
@@ -9,6 +9,10 @@ const ipc = electron.ipcRenderer
 const remote = electron.remote
 const shell = electron.shell
 
+const currentWindow = remote.getCurrentWindow()
+
+const { createGroceryList } = remote.require('./main')
+
 $('#save-recipe-btn').on('click', () => {
   const title = $('#title-field').val();
   const link = $('#url-field').val();
@@ -33,6 +37,7 @@ const validateUrl = (link) => {
 }
 
 $('#grocery-list-btn').on('click', (e) => {
-  //when I click on the grocery list button, a text area should pop up with a save button.
   e.preventDefault()
-})
+  //when I click on the grocery list button, a text area should pop up with a save button.
+  createGroceryList()
+}) // new window will not pop up


### PR DESCRIPTION
I'm mainly making this PR as a reference for what to go over tomorrow. I tried to start the grocery list by simply making a new browser window when a grocery list button was clicked. I set things up similar to our multiple windows in electron lesson:
const windows = new Set()
```
+// creates fancy array of windows
+
+const createGroceryList = exports.createGroceryList = (file) => {
+  let groceryWindow = new BrowserWindow({show: false})
+  windows.add(groceryWindow)
+  //creates a new window for the grocery list and defaults it to not show. We add this window to the window Set
+
+  //load grocery list file
+  groceryWindow.loadURL('file://' + __dirname + '/grocery-list.html')
+
+  groceryWindow.once('ready-to-show', () => {
+    if (file) openFile(groceryWindow, file)
+    groceryWindow.show()
+    //Once the new window is ready to show, we will call openFiel if there is a file to open with the new window. Then we show the new window.
+  })
+
+  return groceryWindow
+}
```
 However,  I don't get a new window on the click of the button: 
```
$('#grocery-list-btn').on('click', (e) => {
+  e.preventDefault()
+  //when I click on the grocery list button, a text area should pop up with a save button.
+  createGroceryList()
+}) // new window will not pop up
```
